### PR TITLE
Flatten the output list in `list_values_with_key_prefix`

### DIFF
--- a/smartgpt/jvm.py
+++ b/smartgpt/jvm.py
@@ -63,7 +63,10 @@ def all():
 
 def list_values_with_key_prefix(prefix):
     try:
-        values = [get(key) for key in kv_store.keys() if key.startswith(prefix)]
+        values = []
+        for key in kv_store.keys():
+            if key.startswith(prefix):
+                values.extend(get(key))
         return values
     except Exception as e:
         logging.fatal(f"list_values_with_key_prefix, An error occurred: {e}")


### PR DESCRIPTION
The `list_values_with_key_prefix` function was originally returning a nested list because the `get(key)` function returned a list for each key. This has been fixed by extending the `values` list with each returned list instead of appending it, which resulted in a flat list. 



