### PR TITLE
Refactor project structure and improve import handling

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,2 @@
+PYTHONPATH=/path/to/myproject
+OPENAI_API_KEY=<TOKEN>

--- a/README.md
+++ b/README.md
@@ -7,26 +7,27 @@
 - Run `pipenv shell` to enter the Python virtual environment and `pipenv install` to install the dependencies.
 - Rename `.env.template` to `.env` and fill in your [`OPENAI_API_KEY`](https://platform.openai.com/account/api-keys),
   and optionally [`ELEVEN_LABS_API_KEY`](https://elevenlabs.io) (for speech).
+- Please add the absolute path of the project directory to your PYTHONPATH environment variable and set it in your .env file
 
 ## Usage
 
 Run the following command to start the program:
 
 ```bash
-python smartgpt/main.py --continuous --timeout 3 --config=./config.yaml --startseq=0 --verbose --replan
+python main.py --continuous --timeout 3 --config=./config.yaml --startseq=0 --verbose --replan
 ```
 
 
 Once we have a plan, simplify it by running the command:
 ```bash
-python smartgpt/main.py --continuous --timeout 3 --config=./config.yaml --startseq=0 --verbose --replan
+python main.py --continuous --timeout 3 --config=./config.yaml --startseq=0 --verbose --replan
 ```
 
 
 Then we can run the generated instructions by executing the following commands:
 ```bash
-python smartgpt/main.py --continuous --timeout 3 --config=./config.yaml --startseq=0 --verbose --json=1.json
-python smartgpt/main.py --continuous --timeout 3 --config=./config.yaml --startseq=0 --verbose --json=2.json
+python main.py --continuous --timeout 3 --config=./config.yaml --startseq=0 --verbose --json=1.json
+python main.py --continuous --timeout 3 --config=./config.yaml --startseq=0 --verbose --json=2.json
 ```
 
 

--- a/main.py
+++ b/main.py
@@ -1,17 +1,17 @@
 from typing import Optional
 from dotenv import load_dotenv
-from spinner import Spinner
-import gpt
-from smartgpt import jvm
-import actions
 import ast
-
 import os, sys, time, re, signal, argparse, logging, pprint
 import ruamel.yaml as yaml
 from datetime import datetime
-import planner
 import json
-import utils
+
+from smartgpt.spinner import Spinner
+from smartgpt import actions
+from smartgpt import planner
+from smartgpt import utils
+from smartgpt import gpt
+from smartgpt import jvm
 
 base_model  = gpt.GPT_3_5_TURBO_16K
 
@@ -78,8 +78,6 @@ class Instruction:
         if action_type != "RunPython":
             # todo: handle error if the result is not a json 
             self.post_exec(result)
-
-    
 
     def eval_and_patch(self, text):
         while True:
@@ -282,9 +280,3 @@ if __name__ == "__main__":
     interpreter = JVMInterpreter()
     logging.info(f"Running instructions from  {plan_with_instrs['instructions'][start_seq]}\n")
     interpreter.run(plan_with_instrs["instructions"][start_seq:], goal=plan_with_instrs["goal"])
-
-
-
-
-
-    

--- a/smartgpt/actions.py
+++ b/smartgpt/actions.py
@@ -1,9 +1,5 @@
 from dataclasses import dataclass, field
-
 import io, subprocess, os, inspect, json, logging, time, re
-from smartgpt import gpt
-from smartgpt import jvm
-from smartgpt.spinner import Spinner
 from typing import Union,List, Dict
 from abc import ABC
 from urllib.error import HTTPError
@@ -18,6 +14,10 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from webdriver_manager.chrome import ChromeDriverManager
+
+from smartgpt import gpt
+from smartgpt import jvm
+from smartgpt.spinner import Spinner
 
 
 _cache = {}

--- a/smartgpt/planner.py
+++ b/smartgpt/planner.py
@@ -1,9 +1,10 @@
 from typing import Optional
 from dotenv import load_dotenv
 import time, logging
-import gpt
 import json
-import translator
+
+from smartgpt import gpt
+from smartgpt import translator
 
 GEN_PLAN__SYS_PROMPT = """
 As Jarvis, your role as an AI model is to generate and structure tasks for execution by an automated agent (auto-agent). 

--- a/smartgpt/translator.py
+++ b/smartgpt/translator.py
@@ -1,7 +1,8 @@
 import json
 import logging
 import time
-import gpt
+
+from smartgpt import gpt
 
 TRANSLATE_PLAN_SYS_PROMPT = """
 As Jarvis, an AI model with the role of translating task into JVM's instructions. You will fully leverage user's hints(if exist), reuse them to generate instructions efficiently.

--- a/smartgpt/utils.py
+++ b/smartgpt/utils.py
@@ -1,7 +1,6 @@
 # Description: Utility functions
-
-
 import logging
+
 from smartgpt import jvm
 
 


### PR DESCRIPTION
In this PR, the project structure has been refactored to improve module importing consistency across the project and its tests.

Specifically, the changes include:

1. New layout treats the 'smartgpt' as a package, and 'main.py' is located at the project's root. This structure better aligns with Python packaging and distribution standards.

2. Modifying module import statements within the 'smartgpt' package. Modules now import each other using fully qualified names (e.g., from 'smartgpt' import interpreter instead of import interpreter). This change makes imports more predictable and reduces the chance of naming conflicts.

3. Adding instructions in the README about how to set the PYTHONPATH environment variable to include the project directory. This is necessary for Python to find the 'smartgpt' package and its modules when running scripts in different directories.

These changes aim to make the codebase more robust, easier to understand, and more conformant to Python best practices. They should not affect the project's functionality.