### PR TITLE
Fix python run with jvm

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,10 +74,10 @@ class JVMInterpreter:
             ]
         }
         evaluation_action = actions.TextCompletionAction(
-            -1,
-            "Is that true or false?",
-            condition,
-            yaml.safe_dump(output_fmt))
+            action_id = -1,
+            command = "Is that true or false?",
+            content = condition,
+            output_fmt = yaml.safe_dump(output_fmt))
 
         try:
             evaluation_result = evaluation_action.run()
@@ -95,14 +95,14 @@ class JVMInterpreter:
         old_pc = self.pc
         if condition_eval_result:
             # instruction.instruction["then"] is a list of instructions
-            if "then" in jvm_instr.instruction:
+            if "then" in jvm_instr.instruction.get("args", {}):
                 self.pc = 0
-                self.run(jvm_instr.instruction["then"], jvm_instr.goal)
+                self.run(jvm_instr.instruction["args"]["then"], jvm_instr.goal)
         else:
             # maybe use pc to jump is a better idea.
-            if "else" in jvm_instr.instruction:
+            if "else" in jvm_instr.instruction.get("args", {}):
                 self.pc = 0
-                self.run(jvm_instr.instruction["else"], jvm_instr.goal)
+                self.run(jvm_instr.instruction["args"]["else"], jvm_instr.goal)
         self.pc = old_pc
 
 

--- a/smartgpt/jvm.py
+++ b/smartgpt/jvm.py
@@ -33,8 +33,8 @@ def get(key, default=None):
             # This is a list
             return list(ast.literal_eval(value))
         return value
-    except Exception as e:
-        logging.fatal(f"get, An error occurred: {e}")
+    except Exception as err:
+        logging.fatal(f"get, An error occurred: {err}")
         return default
 
 def set(key, value):
@@ -44,8 +44,8 @@ def set(key, value):
             value = repr(value)
         kv_store[key] = value
         save_kv_store()
-    except Exception as error:
-        logging.fatal(f"set, An error occurred: {error}")
+    except Exception as err:
+        logging.fatal(f"set, An error occurred: {err}")
 
 
 def list_values_with_key_prefix(prefix):
@@ -56,16 +56,16 @@ def list_values_with_key_prefix(prefix):
                 values.append(get(key))
         #logging.info(f"list_values_with_key_prefix, values: {values}")
         return values
-    except Exception as e:
-        logging.fatal(f"list_values_with_key_prefix, An error occurred: {e}")
+    except Exception as err:
+        logging.fatal(f"list_values_with_key_prefix, An error occurred: {err}")
         return []
 
 def list_keys_with_prefix(prefix):
     try:
         keys = [key for key in kv_store.keys() if key.startswith(prefix)]
         return keys
-    except Exception as e:
-        logging.fatal(f"list_keys_with_prefix, An error occurred: {e}")
+    except Exception as err:
+        logging.fatal(f"list_keys_with_prefix, An error occurred: {err}")
         return []
 
 def set_loop_idx(value):
@@ -106,8 +106,8 @@ def eval(text, lazy_eval_prefix=LAZY_EVAL_PREFIX):
 
     try:
         evaluated = utils.sys_eval(expression)
-    except Exception as e:
-        logging.critical(f"Failed to evaluate {expression}. Error: {str(e)}")
+    except Exception as err:
+        logging.critical(f"Failed to evaluate {expression}. Error: {str(err)}")
         return None
 
     # replace the evaluated part in the original string


### PR DESCRIPTION
In order to make the Python scripts generated in the `workspace` directory normally work with `jvm.get()` and `jvm.set()`, you need to manually copy smartgpt/jvm.py to the `workspace` directory and remove `from smartgpt import utils` and `def eval()` definition.