### PR TITLE
Fix bugs in JVM translator

### DIFF
--- a/data/prompts/reviewer_index_key
+++ b/data/prompts/reviewer_index_key
@@ -3,7 +3,7 @@ Please complete the following YAML template for your response:
 original_version: |
 {instructions}
 review_requirement: |
-  Carefully inspect all instructions within Loop structures. Alert any occurrences where an index key is not utilized in output argument. This is crucial as data overwriting could occur from key reuse, often indicating a bug. Your keen observation is vital for ensuring proper data manipulation within loop structures.
+  Carefully inspect instructions within Loop instruction. Alert any occurrences where an index key is not utilized in output argument. This is crucial as data overwriting could occur from key reuse, often indicating a bug. Your keen observation is vital for ensuring proper data manipulation within Loop.
 approved: <to_fill>
 review_comment: |
   <to_fill>

--- a/jarvis/extensions/jarvis_agent.py
+++ b/jarvis/extensions/jarvis_agent.py
@@ -12,12 +12,13 @@ import traceback
 from pydantic import BaseModel
 import yaml
 
+from jarvis.smartgpt import initializer
 from jarvis.smartgpt import planner
 from jarvis.smartgpt import instruction
 from jarvis.smartgpt import jvm
 from jarvis.smartgpt import gpt
 from jarvis.smartgpt.compiler import Compiler
-from jarvis.smartgpt import initializer
+
 
 # Initialize the Jarvis environment
 initializer.setup()

--- a/jarvis/smartgpt/gpt.py
+++ b/jarvis/smartgpt/gpt.py
@@ -7,6 +7,8 @@ from typing import Optional, List, Dict
 import openai
 import tiktoken
 
+import jarvis.smartgpt.initializer
+
 
 API_TYPE = os.getenv("OPENAI_API_TYPE")
 

--- a/jarvis/smartgpt/translator.py
+++ b/jarvis/smartgpt/translator.py
@@ -26,8 +26,7 @@ class Translator:
 
     def build_system_prompt(self) -> List[Dict]:
         messages = []
-        messages.append({"role": "system", "content": preprompts.get("translator_sys")})
-        messages.append({"role": "user", "content": fewshot.get(FEW_SHOT_EXAMPLE)})
+        messages.append({"role": "system", "content": preprompts.get("translator_sys") + "\n" + fewshot.get(FEW_SHOT_EXAMPLE)})
         return messages
 
     def translate_to_instructions(self, task_info: Dict[str, Any]):


### PR DESCRIPTION
1. Move the example back to the system prompt
2. Fix the position where initialize environment variables